### PR TITLE
#229 fixes high score trophy error

### DIFF
--- a/server/lib/trophy-methods.js
+++ b/server/lib/trophy-methods.js
@@ -14,7 +14,7 @@ function getFirstQuizState (client, user_id, quiz_id, callback) {
     query(client, queries.getFirstQuizState, [user_id, quiz_id], (error, result) => {
 
         if (error) {
-            throw new Error();
+            return callback(new Error("Problem with getting first quiz state"));
         }
         callback(null, result.rowCount > 0);
     });
@@ -30,17 +30,22 @@ function getFirstQuizState (client, user_id, quiz_id, callback) {
 
 function getHighScoreState (client, user_id, module_id, percentageScore, callback) {
 
-    query(client, queries.getHighScoreState.getCurrentHighScore, [user_id, module_id], (error, high_score) => {
+    query(client, queries.getHighScoreState.getCurrentHighScore, [user_id, module_id], (error, result1) => {
+        
+        if (error) {
+            return callback(new Error("Problem with getting high score"));
+        }    
+        var high_score = result1.rows[0].high_score;
 
         if (high_score) {
             return callback(null, true);
         } else {
-            query(client, queries.getHighScoreState.getCondition, [module_id], (error, result) => {
+            query(client, queries.getHighScoreState.getCondition, [module_id], (error, result2) => {
 
                 if (error) {
-                    throw new Error("Problem with getting high score");
+                    return callback(new Error("Problem with getting high score"));
                 }
-                var threshold = result.rows[0].condition;
+                var threshold = result2.rows[0].condition;
 
                 callback(null, percentageScore >= threshold);
             });
@@ -62,7 +67,7 @@ function getOverallAverageState (client, user_id, module_id, callback) {
 
         if (error) {
             console.error(error);
-            callback(new Error("Problem with getting overall average data"));
+            return callback(new Error("Problem with getting overall average data"));
         }
         var overall_average = result.rows[0].overall_average;
 
@@ -70,7 +75,7 @@ function getOverallAverageState (client, user_id, module_id, callback) {
 
             if (error) {
                 console.error(error);
-                callback(new Error("Problem with getting overall average data"));
+                return callback(new Error("Problem with getting overall average data"));
             }
             var threshold = condition.rows[0].condition;
 
@@ -94,7 +99,7 @@ function getParticipationState (client, user_id, module_id, callback) {
 
         if (error) {
             console.error(error);
-            callback(new Error("Problem with getting participation data"));
+            return callback(new Error("Problem with getting participation data"));
         }
         var participation = result.rows[0].participation;
 
@@ -102,7 +107,7 @@ function getParticipationState (client, user_id, module_id, callback) {
 
             if (error) {
                 console.error(error);
-                callback(new Error("Problem with getting participation data"));
+                return callback(new Error("Problem with getting participation data"));
             }
             var threshold = condition.rows[0].condition;
 


### PR DESCRIPTION
high score trophy always awarded due to `if (high_score)` condition always evaluating to true.  `high_score` was an object, instead of a boolean value.

Adds better error handling