### PR TITLE
Email stub

### DIFF
--- a/test/back/endpoints/auth.test.js
+++ b/test/back/endpoints/auth.test.js
@@ -384,7 +384,7 @@ const franzCreds = { email: 'franzmoro@hotmail.com', password: 'testinglecturer'
             email.restore();
             t.error(err); 
         });
-    })
+    });
 
 });
 

--- a/test/back/endpoints/auth.test.js
+++ b/test/back/endpoints/auth.test.js
@@ -6,6 +6,11 @@ const pool = require('../../utils/dbClient.js');
 const redisCli = server.app.redisCli;
 const initDb = require('../../utils/initDb.js')(pool, redisCli);
 
+const sinon = require('sinon');
+const sendemail = require('sendemail');
+
+let email;
+
 const {
     questions,
     updateQuizOptionsPayload,
@@ -64,6 +69,15 @@ const franzCreds = { email: 'franzmoro@hotmail.com', password: 'testinglecturer'
         t.plan(1);
 
         initDb()
+        .then(() => {
+            email = sinon.stub(
+                sendemail,
+                'email',
+                (name, person, cb) => cb(null)
+            );
+
+            return Promise.resolve();
+        })
         .then(() => simulateAuth())
         .then(() => {
             const faketoken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2RldGFpbHMiOnsiZW1haWwiOiJsZWN0dXJlckBjaXR5LmFjLnVrIiwiaXNfbGVjdHVyZXIiOnRydWUsInVzZXJuYW1lIjoibGVjdHVyZXIiLCJpc192ZXJpZmllZCI6dHJ1ZSwidmVyaWZpY2F0aW9uX2NvZGUiOm51bGwsInJlc2V0X3Bhc3N3b3JkX2NvZGUiOm51bGwsImV4cGlyeV9jb2RlIjpudWxsfSwidWlkIjoiNTQ3NmYyMzAtZDQzNy0xMWU2LThmMDYtOGRmNTk1ZjYyYmIzIiwiaWF0IjoxNDgzNzI0NDc4fQ.iNGYZZtYuBLo8Qbf1NnApt4qNMoczpWw991yIzdraxE';
@@ -78,9 +92,11 @@ const franzCreds = { email: 'franzmoro@hotmail.com', password: 'testinglecturer'
             return server.inject(options);
         })
         .then((response) => {
+            email.restore();
             t.equal(response.statusCode, 401, '401 status code for ' + endpoint.url);
         })
         .catch((err) => {
+            email.restore();
             t.error(err);
         });
     });
@@ -89,6 +105,15 @@ const franzCreds = { email: 'franzmoro@hotmail.com', password: 'testinglecturer'
         t.plan(1);
 
         initDb()
+        .then(() => {
+            email = sinon.stub(
+                sendemail,
+                'email',
+                (name, person, cb) => cb(null)
+            );
+
+            return Promise.resolve();
+        })
         .then(() => simulateAuth())
         .then(() => {
             const faketoken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2RldGFpbHMiOnsidXNlcl9pZCI6MiwiZW1haWwiOiJsZWN0dXJlckBjaXR5LmFjLnVrIiwiaXNfbGVjdHVyZXIiOnRydWUsInVzZXJuYW1lIjoibGVjdHVyZXIiLCJpc192ZXJpZmllZCI6dHJ1ZSwidmVyaWZpY2F0aW9uX2NvZGUiOm51bGwsInJlc2V0X3Bhc3N3b3JkX2NvZGUiOm51bGwsImV4cGlyeV9jb2RlIjpudWxsfSwidWlkIjoiODhiZjI2ZDAtZDQzNi0xMWU2LWFkYjAtZWQxZmMzc29oaWwiLCJpYXQiOjE0ODM3MjQxMzZ9.eIUlEMiXltreNapzBhDwbQjfF0YwWPqFE5qCyxS51aE';
@@ -103,9 +128,11 @@ const franzCreds = { email: 'franzmoro@hotmail.com', password: 'testinglecturer'
             return server.inject(options);
         })
         .then((response) => {
+            email.restore();
             t.equal(response.statusCode, 401, '401 status code for ' + endpoint.url);
         })
         .catch((err) => {
+            email.restore();
             t.error(err); 
         });
     });
@@ -114,6 +141,15 @@ const franzCreds = { email: 'franzmoro@hotmail.com', password: 'testinglecturer'
         t.plan(1);
 
         initDb()
+        .then(() => {
+            email = sinon.stub(
+                sendemail,
+                'email',
+                (name, person, cb) => cb(null)
+            );
+
+            return Promise.resolve();
+        })
         .then(() => simulateAuth())
         .then((token) => {
 
@@ -127,9 +163,11 @@ const franzCreds = { email: 'franzmoro@hotmail.com', password: 'testinglecturer'
             return server.inject(options);
         })
         .then((response) => {
+            email.restore();
             t.equal(response.statusCode, 200, '200 status code');
         })
         .catch((err) => {
+            email.restore();
             t.error(err); 
         });
     });
@@ -138,6 +176,15 @@ const franzCreds = { email: 'franzmoro@hotmail.com', password: 'testinglecturer'
         t.plan(1);
 
         initDb()
+        .then(() => {
+            email = sinon.stub(
+                sendemail,
+                'email',
+                (name, person, cb) => cb(null)
+            );
+
+            return Promise.resolve();
+        })
         .then(() => {
 
             const options = {
@@ -149,9 +196,11 @@ const franzCreds = { email: 'franzmoro@hotmail.com', password: 'testinglecturer'
             return server.inject(options);
         })
         .then((response) => {
+            email.restore();
             t.equal(response.statusCode, 401, '401 status code for ' + endpoint.url);
         })
         .catch((err) => {
+            email.restore();
             t.error(err); 
         });
     });
@@ -166,6 +215,15 @@ const franzCreds = { email: 'franzmoro@hotmail.com', password: 'testinglecturer'
         t.plan(1);
 
         initDb()
+        .then(() => {
+            email = sinon.stub(
+                sendemail,
+                'email',
+                (name, person, cb) => cb(null)
+            );
+
+            return Promise.resolve();
+        })
         .then(() => simulateAuthStudents())
         .then(() => {
             const faketoken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2RldGFpbHMiOnsiZW1haWwiOiJsZWN0dXJlckBjaXR5LmFjLnVrIiwiaXNfbGVjdHVyZXIiOnRydWUsInVzZXJuYW1lIjoibGVjdHVyZXIiLCJpc192ZXJpZmllZCI6dHJ1ZSwidmVyaWZpY2F0aW9uX2NvZGUiOm51bGwsInJlc2V0X3Bhc3N3b3JkX2NvZGUiOm51bGwsImV4cGlyeV9jb2RlIjpudWxsfSwidWlkIjoiNTQ3NmYyMzAtZDQzNy0xMWU2LThmMDYtOGRmNTk1ZjYyYmIzIiwiaWF0IjoxNDgzNzI0NDc4fQ.iNGYZZtYuBLo8Qbf1NnApt4qNMoczpWw991yIzdraxE';
@@ -180,9 +238,11 @@ const franzCreds = { email: 'franzmoro@hotmail.com', password: 'testinglecturer'
             return server.inject(options);
         })
         .then((response) => {
+            email.restore();
             t.equal(response.statusCode, 401, '401 status code for ' + endpoint.url);
         })
         .catch((err) => {
+            email.restore();
             t.error(err); 
         });
     });
@@ -191,6 +251,15 @@ const franzCreds = { email: 'franzmoro@hotmail.com', password: 'testinglecturer'
         t.plan(1);
 
         initDb()
+        .then(() => {
+            email = sinon.stub(
+                sendemail,
+                'email',
+                (name, person, cb) => cb(null)
+            );
+
+            return Promise.resolve();
+        })
         .then(() => simulateAuthStudents())
         .then(() => {
             const faketoken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2RldGFpbHMiOnsidXNlcl9pZCI6MiwiZW1haWwiOiJsZWN0dXJlckBjaXR5LmFjLnVrIiwiaXNfbGVjdHVyZXIiOnRydWUsInVzZXJuYW1lIjoibGVjdHVyZXIiLCJpc192ZXJpZmllZCI6dHJ1ZSwidmVyaWZpY2F0aW9uX2NvZGUiOm51bGwsInJlc2V0X3Bhc3N3b3JkX2NvZGUiOm51bGwsImV4cGlyeV9jb2RlIjpudWxsfSwidWlkIjoiODhiZjI2ZDAtZDQzNi0xMWU2LWFkYjAtZWQxZmMzc29oaWwiLCJpYXQiOjE0ODM3MjQxMzZ9.eIUlEMiXltreNapzBhDwbQjfF0YwWPqFE5qCyxS51aE';
@@ -205,9 +274,11 @@ const franzCreds = { email: 'franzmoro@hotmail.com', password: 'testinglecturer'
             return server.inject(options);
         })
         .then((response) => {
+            email.restore();
             t.equal(response.statusCode, 401, '401 status code for ' + endpoint.url);
         })
         .catch((err) => {
+            email.restore();
             t.error(err); 
         });
     });
@@ -216,9 +287,17 @@ const franzCreds = { email: 'franzmoro@hotmail.com', password: 'testinglecturer'
         t.plan(1);
 
         initDb()
+        .then(() => {
+            email = sinon.stub(
+                sendemail,
+                'email',
+                (name, person, cb) => cb(null)
+            );
+
+            return Promise.resolve();
+        })
         .then(() => simulateAuthStudents())
         .then((token) => {
-
             const options = {
                 method: endpoint.method || 'get',
                 url: endpoint.url,
@@ -229,9 +308,11 @@ const franzCreds = { email: 'franzmoro@hotmail.com', password: 'testinglecturer'
             return server.inject(options);
         })
         .then((response) => {
+            email.restore();
             t.equal(response.statusCode, 200, '200 status code');
         })
         .catch((err) => {
+            email.restore();
             t.error(err); 
         });
     });
@@ -241,7 +322,15 @@ const franzCreds = { email: 'franzmoro@hotmail.com', password: 'testinglecturer'
 
         initDb()
         .then(() => {
+            email = sinon.stub(
+                sendemail,
+                'email',
+                (name, person, cb) => cb(null)
+            );
 
+            return Promise.resolve();
+        })
+        .then(() => {
             const options = {
                 method: endpoint.method || 'get',
                 url: endpoint.url,
@@ -251,9 +340,11 @@ const franzCreds = { email: 'franzmoro@hotmail.com', password: 'testinglecturer'
             return server.inject(options);
         })
         .then((response) => {
+            email.restore();
             t.equal(response.statusCode, 401, '401 status code for ' + endpoint.url);
         })
         .catch((err) => {
+            email.restore();
             t.error(err); 
         });
     });
@@ -274,17 +365,25 @@ const franzCreds = { email: 'franzmoro@hotmail.com', password: 'testinglecturer'
 
         const options = endpoint;
 
+        email = sinon.stub(
+            sendemail,
+            'email',
+            (name, person, cb) => cb(null)
+        );
+
         server.inject(options)
-            .then((response) => {
-                if (response.statusCode === 302) {
-                    t.equal(response.statusCode, 302, endpoint.url + ' doesnt require authentication');
-                    return;
-                }
-                t.equal(response.statusCode, 200, endpoint.url + ' doesnt require authentication');
-            })
-            .catch((err) => {
-                t.error(err); 
-            });
+        .then((response) => {
+            email.restore();
+            if (response.statusCode === 302) {
+                t.equal(response.statusCode, 302, endpoint.url + ' doesnt require authentication');
+                return;
+            }
+            t.equal(response.statusCode, 200, endpoint.url + ' doesnt require authentication');
+        })
+        .catch((err) => {
+            email.restore();
+            t.error(err); 
+        });
     })
 
 });

--- a/test/back/endpoints/endpoints.test.js
+++ b/test/back/endpoints/endpoints.test.js
@@ -10,6 +10,11 @@ const { moduleInfo } = require('../../utils/data-fixtures.js');
 const lecturerCreds = { email: 'authenticate-user@city.ac.uk', password: 'testinglecturer' };
 const franzCreds = { email: 'franzmoro@hotmail.com', password: 'testinglecturer', is_lecturer: true };
 
+const sinon = require('sinon');
+const sendemail = require('sendemail');
+
+let email;
+
 if (!process.env.TESTING) {
     throw new Error("Please set the testing environment variable!");
 }
@@ -18,9 +23,23 @@ test('/ endpoint works returns the correct payload', (t) => {
     t.plan(1);
 
     initDb()
+    .then(() => {
+        email = sinon.stub(
+            sendemail,
+            'email',
+            (name, person, cb) => cb(null)
+        );
+
+        return Promise.resolve();
+    })
     .then(() => server.inject('/'))
     .then((response) => {
+        email.restore();
         t.ok(response.payload.indexOf('<title>Quiz App</title>') > -1, "index page loads correctly!");
+    })
+    .catch((err) => {
+        email.restore();
+        t.error(err);
     });
 });
 
@@ -154,6 +173,15 @@ test('/ endpoint works returns the correct payload', (t) => {
         t.plan(1);
 
         initDb()
+        .then(() => {
+            email = sinon.stub(
+                sendemail,
+                'email',
+                (name, person, cb) => cb(null)
+            );
+
+            return Promise.resolve();
+        })
         .then(() => simulateAuth())
         .then((token) => {
             const options = {
@@ -165,7 +193,12 @@ test('/ endpoint works returns the correct payload', (t) => {
             return server.inject(options);
         })
         .then((response) => {
+            email.restore();
             t.deepEqual(response.result, endpoint.expected, 'payload is correct for ' + endpoint.url);
+        })
+        .catch((err) => {
+            email.restore();
+            t.error(err);
         });
     });
 });
@@ -202,6 +235,15 @@ test('/ endpoint works returns the correct payload', (t) => {
         t.plan(1);
 
         initDb()
+        .then(() => {
+            email = sinon.stub(
+                sendemail,
+                'email',
+                (name, person, cb) => cb(null)
+            );
+
+            return Promise.resolve();
+        })
         .then(() => simulateAuthStudents())
         .then((token) => {
             const options = {
@@ -212,7 +254,12 @@ test('/ endpoint works returns the correct payload', (t) => {
             return server.inject(options);
         })
         .then((response) => {
+            email.restore();
             t.deepEqual(response.result, endpoint.expected, 'payload is correct for ' + endpoint.url);
+        })
+        .catch((err) => {
+            email.restore();
+            t.error(err);
         });
     });
 });

--- a/test/utils/utilsTest/initDb.test.js
+++ b/test/utils/utilsTest/initDb.test.js
@@ -16,7 +16,7 @@ tape('flush db clears pg database', (t) => {
                     if (error) {
                         return t.error(error);
                     }
-                    t.equal(data.rows.length, 33, 'database has been setup');
+                    t.equal(data.rows.length, 34, 'database has been setup');
                 }
             );
         });


### PR DESCRIPTION
Fixes #365 

Stubbing out the `email` method of [sendemail](https://github.com/dwyl/sendemail)

There shouldn't be any more emails sent when running the tests