### PR TITLE
Student quiz history now shows all quiz questions

### DIFF
--- a/server/lib/getQuizDetailsStudent.js
+++ b/server/lib/getQuizDetailsStudent.js
@@ -15,13 +15,13 @@ const getQuestionsForUser = (user_id, rows) => {
                 if (!prevQuestionIdResponse) {
                     const indexOfPrevQuestId = prev
                         .map((question) => question.question_id)
-                        .indexOf(curr.question_id)
+                        .indexOf(curr.question_id);
 
                     return [
                         ...prev.slice(0, indexOfPrevQuestId),
                         curr,
                         ...prev.slice(indexOfPrevQuestId + 1)
-                    ]
+                    ];
                 } else {
                     return prev;
                 }
@@ -39,7 +39,7 @@ const getQuestionsForUser = (user_id, rows) => {
             response: question.response
         }));
 
-}
+};
 
 /**
  * Returns from the database quiz info
@@ -75,6 +75,6 @@ const getQuizDetailsStudent = (client, quiz_id, user_id, callback) => {
 
         callback( null, getQuestionsForUser(user_id, questions.rows));
     });
-}
+};
 
 module.exports = { getQuizDetailsStudent, getQuestionsForUser };

--- a/server/lib/getQuizDetailsStudent.js
+++ b/server/lib/getQuizDetailsStudent.js
@@ -14,24 +14,30 @@ var query = require('./query');
 function getQuizDetailsStudent (client, quiz_id, user_id, callback) {
 
     const questionsQuery = [
-        'SELECT questions.question,',
-        'questions.a, questions.b, questions.c, questions.d,',
-        'questions.correct_answer, responses.response',
-        'FROM questions JOIN responses ON',
-        'questions.quiz_id = $1 AND',
-        'responses.user_id = $2 AND',
-        'questions.quiz_id = responses.quiz_id AND',
-        'questions.question_id = responses.question_id',
-        'ORDER BY questions.question_id;'
+        'SELECT',
+        'q.question, q.a, q.b, q.c, q.d, q.correct_answer, r.response, r.user_id',
+        'FROM',
+        'questions as q',
+        'LEFT OUTER JOIN',
+        'responses as r',
+        'on q.question_id = r.question_id',
+        'WHERE q.quiz_id = $1',
+        'ORDER BY q.question_id'
     ].join(' ');
 
-    query(client, questionsQuery, [quiz_id, user_id], (error, questions) => {
+    query(client, questionsQuery, [quiz_id], (error, questions) => {
         /* istanbul ignore if */
         if (error) {
             console.error(error);
             return callback(error);
         }
-        callback(null, questions.rows);
+
+        callback(
+            null,
+            questions.rows.filter(
+                (row) => !row.user_id || row.user_id === user_id
+            )
+        );
     });
 }
 

--- a/server/plugins/quizes.js
+++ b/server/plugins/quizes.js
@@ -20,7 +20,7 @@ const deleteResponses = require('../lib/deleteResponses.js');
 const getQuizDetails = require('../lib/getQuizDetails.js');
 const getSurveyDetails = require('../lib/getSurveyDetails.js');
 const editScore = require('../lib/editScore.js');
-const getQuizDetailsStudent = require('../lib/getQuizDetailsStudent');
+const getQuizDetailsStudent = require('../lib/getQuizDetailsStudent.js').getQuizDetailsStudent;
 
 const jwt = require('jsonwebtoken');
 const Joi = require('joi');

--- a/test/back/db/getQuestionsForUser.js
+++ b/test/back/db/getQuestionsForUser.js
@@ -71,6 +71,74 @@ const quizIdArray = [
     }
 ];
 
+const quizIdArray2 = [
+    {
+        question: '1111111',
+        a: 'aaaaa',
+        b: 'bbbbbbbb',
+        c: 'ccccccccccccccc',
+        d: 'ddddddddddddddddddd',
+        correct_answer: 'a',
+        question_id: 53,
+        response: undefined,
+        user_id: 1
+    },
+    {
+        question: '1111111',
+        a: 'aaaaa',
+        b: 'bbbbbbbb',
+        c: 'ccccccccccccccc',
+        d: 'ddddddddddddddddddd',
+        correct_answer: 'a',
+        question_id: 53,
+        response: 'a',
+        user_id: 2
+    },
+    {
+        question: '1111111',
+        a: 'aaaaa',
+        b: 'bbbbbbbb',
+        c: 'ccccccccccccccc',
+        d: 'ddddddddddddddddddd',
+        correct_answer: 'a',
+        question_id: 53,
+        response: undefined,
+        user_id: 3
+    },
+    {
+        question: '1111111',
+        a: 'aaaaa',
+        b: 'bbbbbbbb',
+        c: 'ccccccccccccccc',
+        d: 'ddddddddddddddddddd',
+        correct_answer: 'a',
+        question_id: 53,
+        response: 'a',
+    },
+    {
+        question: '22222222222222',
+        a: 'aa',
+        b: 'bb',
+        c: 'cc',
+        d: 'dd',
+        correct_answer: 'b',
+        question_id: 54,
+        response: undefined,
+    },
+    {
+        question: '22222222222222',
+        a: 'aa',
+        b: 'bb',
+        c: 'cc',
+        d: 'dd',
+        correct_answer: 'b',
+        question_id: 54,
+        response: undefined,
+        user_id: 2
+    }
+];
+
+
 const userQuestions = [
     {
         question: '1111111',
@@ -96,6 +164,15 @@ tape('getQuestionsForUser returns the correct questions for a specific user', (t
     t.plan(1);
 
     const actual = getQuestionsForUser(1, quizIdArray);
+    const expected = userQuestions;
+
+    t.deepEqual(actual, expected);
+});
+
+tape('getQuestionsForUser returns the correct questions for a specific user', (t) => {
+    t.plan(1);
+
+    const actual = getQuestionsForUser(1, quizIdArray2);
     const expected = userQuestions;
 
     t.deepEqual(actual, expected);

--- a/test/back/db/getQuestionsForUser.js
+++ b/test/back/db/getQuestionsForUser.js
@@ -1,0 +1,102 @@
+const tape = require('tape');
+
+const getQuestionsForUser = require('../../../server/lib/getQuizDetailsStudent.js').getQuestionsForUser;
+
+const quizIdArray = [
+    {
+        question: '1111111',
+        a: 'aaaaa',
+        b: 'bbbbbbbb',
+        c: 'ccccccccccccccc',
+        d: 'ddddddddddddddddddd',
+        correct_answer: 'a',
+        question_id: 53,
+        response: undefined,
+        user_id: 1
+    },
+    {
+        question: '1111111',
+        a: 'aaaaa',
+        b: 'bbbbbbbb',
+        c: 'ccccccccccccccc',
+        d: 'ddddddddddddddddddd',
+        correct_answer: 'a',
+        question_id: 53,
+        response: 'a',
+        user_id: 2
+    },
+    {
+        question: '1111111',
+        a: 'aaaaa',
+        b: 'bbbbbbbb',
+        c: 'ccccccccccccccc',
+        d: 'ddddddddddddddddddd',
+        correct_answer: 'a',
+        question_id: 53,
+        response: undefined,
+        user_id: 3
+    },
+    {
+        question: '1111111',
+        a: 'aaaaa',
+        b: 'bbbbbbbb',
+        c: 'ccccccccccccccc',
+        d: 'ddddddddddddddddddd',
+        correct_answer: 'a',
+        question_id: 53,
+        response: 'a',
+        user_id: 1
+    },
+    {
+        question: '22222222222222',
+        a: 'aa',
+        b: 'bb',
+        c: 'cc',
+        d: 'dd',
+        correct_answer: 'b',
+        question_id: 54,
+        response: undefined,
+        user_id: 1
+    },
+    {
+        question: '22222222222222',
+        a: 'aa',
+        b: 'bb',
+        c: 'cc',
+        d: 'dd',
+        correct_answer: 'b',
+        question_id: 54,
+        response: undefined,
+        user_id: 2
+    }
+];
+
+const userQuestions = [
+    {
+        question: '1111111',
+        a: 'aaaaa',
+        b: 'bbbbbbbb',
+        c: 'ccccccccccccccc',
+        d: 'ddddddddddddddddddd',
+        correct_answer: 'a',
+        response: 'a',
+    },
+    {
+        question: '22222222222222',
+        a: 'aa',
+        b: 'bb',
+        c: 'cc',
+        d: 'dd',
+        correct_answer: 'b',
+        response: undefined,
+    }
+];
+
+tape('getQuestionsForUser returns the correct questions for a specific user', (t) => {
+    t.plan(1);
+
+    const actual = getQuestionsForUser(1, quizIdArray);
+    const expected = userQuestions;
+
+    t.deepEqual(actual, expected);
+});

--- a/test/back/db/runner.js
+++ b/test/back/db/runner.js
@@ -56,3 +56,4 @@ require('./updateQuestions.test.js');
 require('./updateQuizOrSurvey.test.js');
 require('./validateModuleID.test.js');
 require('./verifyCode.test.js');
+require('./getQuestionsForUser.js');


### PR DESCRIPTION
Fixes #316 

Student history now shows all the questions in the quiz and just the ones you've answered.

Updated the query to get enough data so that no further db callback is needed.

Primarily, implemented a `getQuestionsForUser` function and it's respective test which filters through the db data to be returned.

The `getQuestionsForUser` function is a little ugly, so I'm open to seeing another nicer way of implementing this.