### PR TITLE
Updates wording for privacy statement and consent link in app #715

### DIFF
--- a/src/js/components/dashboard.js
+++ b/src/js/components/dashboard.js
@@ -96,6 +96,7 @@ class Dashboard extends Component {
                 </div>
                 <div className="f-body dashboard__tc" >
                     View <Link className="f-body f-body--primary" target="_blank" to="/privacy">privacy statement</Link>
+                    and <Link className="f-body f-body--primary" target="_blank" to="/privacy#consent">manage data consent</Link>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
As per #715, updates wording of the link in the app for the privacy statement and ensures the 'consent' portion links to the correct anchor in the privacy statement.